### PR TITLE
fix(cb2-3462): add tools-setup npm command that pipeline is expecting

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "start": "cross-env API_VERSION=${npm_package_version} NODE_ENV=local serverless offline start",
     "security-checks": "git secrets --scan",
     "sonar-scanner": "sonar-scanner",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "tools-setup": "echo 'nothing to do for now'"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Adds tools-setup npm command to fix pipeline

`tools-setup` is an npm command that is ran by the Jenkins pipelines (see [here](https://github.com/dvsa/cvs-core-pipeline-scripts/blob/master/feature/Jenkinsfile_feature_build_deploy_services.groovy)) on the backend services. Among some of the other repos (e.g.[ cvs-tsk-update-test-stations](https://github.com/dvsa/cvs-tsk-update-test-stations/blob/develop/package.json),[ cvs-tsk-pull-test-results](https://github.com/dvsa/cvs-tsk-pull-test-results/blob/develop/package.json)) it is a 'do nothing' command.

Related issue: [CB2-3462](https://jira.dvsacloud.uk/browse/CB2-3462)


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works