### PR TITLE
feat(cb2-3462): stop husky prepare script from running during npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start": "cross-env API_VERSION=${npm_package_version} NODE_ENV=local serverless offline start",
     "security-checks": "git secrets --scan",
     "sonar-scanner": "sonar-scanner",
-    "package": "mkdir ${ZIP_NAME} && cp package.json package-lock.json ${ZIP_NAME}/ && cp -r .build/src/* ${ZIP_NAME}/ && cd ${ZIP_NAME} && npm ci --production && rm package.json package-lock.json && zip -qr ../${ZIP_NAME}.zip . && cd .. && rimraf ${ZIP_NAME}",
+    "package": "mkdir ${ZIP_NAME} && cp package.json package-lock.json ${ZIP_NAME}/ && cp -r .build/src/* ${ZIP_NAME}/ && cd ${ZIP_NAME} && npm ci --production --ignore-scripts && rm package.json package-lock.json && zip -qr ../${ZIP_NAME}.zip . && cd .. && rimraf ${ZIP_NAME}",
     "prepare": "husky install",
     "tools-setup": "echo 'nothing to do for now'"
   },


### PR DESCRIPTION
## Stop husky install being ran during npm package

Currently the pipeline is breaking when `npm run package` (which calls `npm ci --production`) is executed in the pipelines. 

The reason for this is because the dev dependencies are not installed when `--production` is used, however `npm ci` continues to try to run the custom `prepare` script (`npm ci` runs `preinstall`, `install`, `postinstall`, `...`, `prepare`, `postprepare`) as normal which finalises the Husky package installation but Husky is a dev dependency and so fails the pipeline as it isn't present.

The `--ignore-scripts` flag stops any custom scripts defined in the `package.json` that `npm ci` runs from being ran.

We've not seen this issue within the other repos that use Husky as they use an older version that does not rely on a `prepare` script to complete the husky installation.

Related issue: [CB2-3462](https://jira.dvsacloud.uk/browse/CB2-3462)


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works